### PR TITLE
add Mailchimp Email newsletter signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,45 @@
       rel="stylesheet"
       href="//api.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css"
     />
+    <link
+      href="//cdn-images.mailchimp.com/embedcode/classic-061523.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <style type="text/css">
+      #mc_embed_shell {
+        width: 100%;
+        display: flex;
+        padding: 1rem 0;
+        justify-content: center;
+      }
+
+      #mc_embed_signup {
+        background:#fff;
+        clear:left;
+        font:14px Helvetica,Arial,sans-serif;
+        width: 600px;
+      }
+
+      #mc_embed_signup .foot {
+        grid-template-columns: 1fr 3fr !important;
+      }
+
+      #mc-embedded-subscribe {
+        color: #606060 !important;
+        background-color: #FBDD70 !important;
+        font-weight: bold !important;
+        font-size: 3rem !important;
+        width: 100% !important;
+        height: auto !important;
+        padding: 1.5rem 0 !important;
+      }
+      #mc-embedded-subscribe:hover {
+        background-color: #caab3c !important;
+      }
+      /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+         We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+    </style>
   </head>
   <body>
     <header>
@@ -212,6 +251,115 @@
     ></div>
 
     <pg-section>
+      <h2 id="newsletter-subscribe" style="width: 100%;">
+        Subscribe to get the latest news for Polyglot YYC 2024!
+      </h2>
+      <div id="mc_embed_shell">
+        <div id="mc_embed_signup">
+          <form
+            action="https://polyglotyyc.us21.list-manage.com/subscribe/post?u=162cf2166a8054e3c7e55e82e&amp;id=e5e01498da&amp;f_id=00a3e7e6f0"
+            method="post"
+            id="mc-embedded-subscribe-form"
+            name="mc-embedded-subscribe-form"
+            class="validate"
+            target="_blank"
+          >
+            <div id="mc_embed_signup_scroll">
+              <div class="indicates-required">
+                <span class="asterisk">*</span> indicates required
+              </div>
+              <div class="mc-field-group">
+                <label for="mce-EMAIL"
+                  >Email Address <span class="asterisk">*</span></label
+                ><input
+                  type="email"
+                  name="EMAIL"
+                  class="required email"
+                  id="mce-EMAIL"
+                  required=""
+                  value=""
+                />
+              </div>
+              <div class="mc-field-group">
+                <label for="mce-FNAME"
+                  >First Name <span class="asterisk">*</span></label
+                ><input
+                  type="text"
+                  name="FNAME"
+                  class="required text"
+                  id="mce-FNAME"
+                  value=""
+                  required=""
+                />
+              </div>
+              <div class="mc-field-group">
+                <label for="mce-LNAME"
+                  >Last Name <span class="asterisk">*</span></label
+                ><input
+                  type="text"
+                  name="LNAME"
+                  class="required text"
+                  id="mce-LNAME"
+                  value=""
+                  required=""
+                />
+              </div>
+              <div id="mce-responses" class="clear foot">
+                <div
+                  class="response"
+                  id="mce-error-response"
+                  style="display: none;"
+                ></div>
+                <div
+                  class="response"
+                  id="mce-success-response"
+                  style="display: none;"
+                ></div>
+              </div>
+              <div
+                aria-hidden="true"
+                style="position: absolute; left: -5000px;"
+              >
+                /* real people should not fill this in and expect good things -
+                do not remove this or risk form bot signups */
+                <input
+                  type="text"
+                  name="b_162cf2166a8054e3c7e55e82e_e5e01498da"
+                  tabindex="-1"
+                  value=""
+                />
+              </div>
+              <div class="optionalParent">
+                <div class="clear foot">
+                  <p style="margin: 0px auto;">
+                    <a
+                      href="http://eepurl.com/iDTJB-"
+                      title="Mailchimp - email marketing made easy and fun"
+                      ><span
+                        style="display: inline-block; background-color: transparent; border-radius: 4px;"
+                        ><img
+                          class="refferal_badge"
+                          src="https://digitalasset.intuit.com/render/content/dam/intuit/mc-fe/en_us/images/intuit-mc-rewards-text-dark.svg"
+                          alt="Intuit Mailchimp"
+                          style="width: 220px; height: 40px; display: flex; padding: 2px 0px; justify-content: center; align-items: center;" /></span
+                    ></a>
+                  </p>
+                  <input
+                    type="submit"
+                    name="subscribe"
+                    id="mc-embedded-subscribe"
+                    class="button"
+                    value="Subscribe"
+                  />
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </pg-section>
+
+    <pg-section>
       <h2>Volunteers</h2>
       <p>
         Polyglot YYC couldn't happen without wonderful volunteers. If you're
@@ -268,6 +416,14 @@
 
       ga('create', 'UA-3057196-9', 'auto');
       ga('send', 'pageview');
+    </script>
+
+    <script
+      type="text/javascript"
+      src="//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"
+    ></script>
+    <script type="text/javascript">
+      (function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';}(jQuery));var $mcj = jQuery.noConflict(true);
     </script>
   </body>
 </html>


### PR DESCRIPTION
# Add Email Newsletter Signup

Adds a form underneath the location section that allows visitors to sign up for newsletter updates. Currently, this is just my personal account for Mailchimp, but I would like to get it transferred to the organization account. 

**Note:** I have hidden the mailing address, as I don't want my address being sent out, and later we can add it back if we have a mailbox/physical address for the organization.

**Note:** Disregard the red icon within the email input, it is just LastPass' UI element 

# Changes
- update index.html with CSS (within the head style tag, regular changes within the `main.css` were not taking effect), JavaScript required for Mailchimp.

## Photos

![image](https://github.com/polyglotyyc/polyglotyyc.github.io/assets/6147502/a6ac4536-54a2-4aef-ace7-391b0d73eed7)
