### PR TITLE
Minor Website Updates & Link social media and mail chimp accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,13 @@ To compile:
 1. install harp
 1. run
 
-```harp compile _harp . ```
+`harp compile _harp . `
+
+### Social Media and Marketing Accounts
+
+For access, please reach out to Matt Frey through Slack. Below are a list of current active accounts:
+
+- [Facebook](https://www.facebook.com/profile.php?id=61554151860042)
+- [Twitter/X]()
+- [Instagram]()
+- [MailChimp](https://mailchimp.com)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
+### Getting Started
+
 To compile:
 
 1. install harp
 1. run
 
 `harp compile _harp . `
+
+### Hosting and Other Details
+
+Current hosting is using GitHub Pages. We are using some third-party services like EventBrite and MailChimp as well.
 
 ### Social Media and Marketing Accounts
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ Current hosting is using GitHub Pages. We are using some third-party services li
 
 For access, please reach out to Matt Frey through Slack. Below are a list of current active accounts:
 
+#### Social Media
+
 - [Facebook](https://www.facebook.com/profile.php?id=61554151860042)
-- [Twitter/X]()
-- [Instagram]()
+- [Twitter/X](https://twitter.com/PolyglotYy24112)
+- [Instagram](https://instagram.com/polyglotyyc?igshid=NGVhN2U2NjQ0Yg==)
+
+#### Emails & Marketing
+
+- polyglotyyc@gmail.com
 - [MailChimp](https://mailchimp.com)
+
+Matt Frey has all the passwords stored for these accounts, if you need access, please send him an email!.

--- a/index.html
+++ b/index.html
@@ -59,10 +59,9 @@
       <div class="mountains"></div>
       <pg-wheat></pg-wheat>
       <h1>Polyglot &nbsp;YYC</h1>
-      <h2>Date: Friday May 3rd, 2024</h2>
+      <h2>Date: TBD</h2>
       <h2>Location: Coming soon</h2>
-      <h2>Breakfast & Lunch provided</h2>
-      <pg-tickets></pg-tickets>
+      <!-- <pg-tickets></pg-tickets> -->
     </header>
 
     <pg-section>
@@ -182,7 +181,7 @@
       <p>
         Polyglot YYC is made possible by our generous sponsors. If you are
         interested in sponsorship opportunities please contact us at on the
-        Slack channel (reach out to Matt Frey, Roger Kondrat, or Yves Dorfsman).
+        Slack channel (reach out to Matt Frey or Yves Dorfsman).
       </p>
     </pg-section>
 


### PR DESCRIPTION
- Reverts the event date since we may have to change it.
- provides links to all of the social media  accounts
- provides links to mailchimp and gmail account created for social media accounts